### PR TITLE
Remove extra module.hot check

### DIFF
--- a/template/src/index.js
+++ b/template/src/index.js
@@ -9,9 +9,7 @@ const root = document.getElementById('root');
 render(<Presentation/>, root);
 
 if (module.hot) {
-  if (module.hot) {
-    module.hot.accept();
-  }
+  module.hot.accept();
 }
 
 registerServiceWorker();


### PR DESCRIPTION
Not sure if this extra `module.hot` check was needed but my spectacle presentation works just fine with the one. If there is some reason for it, maybe a comment documenting that is a good idea.