### PR TITLE
Fix missing font "Montserrat"

### DIFF
--- a/template/src/presentation.js
+++ b/template/src/presentation.js
@@ -27,7 +27,7 @@ const theme = createTheme({
   tertiary: "#03A9FC",
   quarternary: "#CECECE"
 }, {
-  primary: "Montserrat",
+  primary: { name: "Montserrat", googleFont: true, styles: ["400", "700"] },
   secondary: "Helvetica"
 });
 


### PR DESCRIPTION
The default template is using the Montserrat font, which is not included by default with any of the operating systems. This PR declares the font as a google font so that it's displayed correctly.