### PR TITLE
Add raw-loader to webpack configs inside react-scripts

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -213,6 +213,12 @@ module.exports = {
               },
             ],
           },
+          // The raw-loader allows importing of text files so their content
+          // can be used in components like the CodePane.
+          {
+            test: [/\.txt$/, /\.md$/, /\.example$/],
+            use: 'raw-loader',
+          },
           // "file" loader makes sure those assets get served by WebpackDevServer.
           // When you `import` an asset, you get its (virtual) filename.
           // In production, they would get copied to the `build` folder.

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -239,6 +239,12 @@ module.exports = {
             ),
             // Note: this won't work without `new ExtractTextPlugin()` in `plugins`.
           },
+          // The raw-loader allows importing of text files so their content
+          // can be used in components like the CodePane.
+          {
+            test: [/\.txt$/, /\.md$/, /\.example$/],
+            use: 'raw-loader',
+          },
           // "file" loader makes sure assets end up in the `build` folder.
           // When you `import` an asset, you get its filename.
           // This loader doesn't use a "test" so it will catch all modules

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -50,6 +50,7 @@
     "postcss-loader": "2.0.8",
     "promise": "8.0.1",
     "raf": "3.4.0",
+    "raw-loader": "^0.5.1",
     "react-dev-utils": "^4.2.1",
     "spectacle": "^4.0.0",
     "style-loader": "0.19.0",


### PR DESCRIPTION
This PR adds the raw-loader to the webpack configs to support importing text files.

The main use case for this is to show code examples inside the `<CodePane>` as [documented](http://formidable.com/open-source/spectacle/docs/tag-api/#codepane-base). Since this appears to be a common pattern, including the raw-loader directly in spectacle-scripts allows creators to follow the examples in the documentation without having to eject and figure out how to add the raw-loader themselves.