### PR TITLE
fix spelling of quaternary

### DIFF
--- a/packages/react-scripts/template/src/presentation.js
+++ b/packages/react-scripts/template/src/presentation.js
@@ -25,7 +25,7 @@ const theme = createTheme(
     primary: 'white',
     secondary: '#1F2022',
     tertiary: '#03A9FC',
-    quartenary: '#CECECE',
+    quaternary: '#CECECE',
   },
   {
     primary: 'Montserrat',


### PR DESCRIPTION
This PR corrects the spelling of `quaternary` to match the default spectacle theme